### PR TITLE
Add usb-detection to allow start without PowerMate

### DIFF
--- a/knob-ts/package-lock.json
+++ b/knob-ts/package-lock.json
@@ -3989,6 +3989,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter2": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
+      "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
+    },
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -7494,6 +7499,11 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10225,6 +10235,41 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "usb-detection": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/usb-detection/-/usb-detection-4.10.0.tgz",
+      "integrity": "sha512-YUzVWXwfSviE2pInXCKYXhR5heY9GUzlWsdZYxb/Br1Xela6P31A0KDHm7XW0Wsku1HwrokZx+/OD8cZSPHR3w==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "eventemitter2": "^5.0.1",
+        "nan": "^2.13.2",
+        "prebuild-install": "^5.3.5"
+      },
+      "dependencies": {
+        "prebuild-install": {
+          "version": "5.3.6",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
+          "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
     },
     "use": {
       "version": "3.1.1",

--- a/knob-ts/package.json
+++ b/knob-ts/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@svrooij/sonos": "^2.2.0",
-    "node-hid": "^2.1.1"
+    "node-hid": "^2.1.1",
+    "usb-detection": "^4.10.0"
   }
 }


### PR DESCRIPTION
> This is ugly but it mostly works... should probably refactor this and make it prettier `¯\_(ツ)_/¯ `

The main motivation here was that I was unable to start the script without the PowerMate plugged into my development machine, which was impeding my experience while writing up the Nuimo input class/implementation. So this is mostly just a chore, but it makes the library a little more robust so I'm fine with that.

This lets me still set up a `new PowerMate()` in the index without there necessarily being a PowerMate plugged in - the idea is I can define what a PowerMate _would_ do when it is plugged in, and it will become active once the USB device is available. Very narrow use case in production, very common situation in development for me. Scratching my own itch here.

Here's a video:


https://user-images.githubusercontent.com/3157928/103259989-cdea2500-4969-11eb-8d4c-488ad28d9357.mp4




