### PR TITLE
Add Nuimo to knob-ts

### DIFF
--- a/knob-ts/README.md
+++ b/knob-ts/README.md
@@ -5,7 +5,7 @@ Custom adapter library to map inputs and outputs for Media Cube
 It will map the following inputs:
 
 - [x] Griffin PowerMate
-- [ ] Senic Nuimo
+- [x] Senic Nuimo
 
 to the following outputs:
 
@@ -42,6 +42,18 @@ Then reload `udev` rules:
 
 ```bash
 $ sudo udevadm control --reload-rules
+```
+
+### Nuimo
+
+Install and configure drivers for Nuimo (`rocket-nuimo` uses `noble` and they have some setup steps):
+
+```bash
+# https://github.com/noble/noble#ubuntudebianraspbian
+$ sudo apt-get install bluetooth bluez libbluetooth-dev libudev-dev
+
+# https://github.com/noble/noble#running-on-linux
+$ sudo setcap cap_net_raw+eip $(eval readlink -f `which node`)
 ```
 
 ### pm2

--- a/knob-ts/package-lock.json
+++ b/knob-ts/package-lock.json
@@ -4,6 +4,57 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@abandonware/bluetooth-hci-socket": {
+      "version": "0.5.3-6",
+      "resolved": "https://registry.npmjs.org/@abandonware/bluetooth-hci-socket/-/bluetooth-hci-socket-0.5.3-6.tgz",
+      "integrity": "sha512-LwZtu31vgcm6T4GRtHDCye1JZepvjfqW418DYccgcu4podXbBoogkt4NhRP6rnoOxY+49F1Do7oK5K8fModxuw==",
+      "optional": true,
+      "requires": {
+        "debug": "^4.2.0",
+        "nan": "^2.14.1",
+        "node-pre-gyp": "^0.15.0",
+        "usb": "^1.6.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "optional": true
+        }
+      }
+    },
+    "@abandonware/noble": {
+      "version": "1.9.2-10",
+      "resolved": "https://registry.npmjs.org/@abandonware/noble/-/noble-1.9.2-10.tgz",
+      "integrity": "sha512-V43V5kDlDCfM8PK88QTqFZU+UmJheuwJS0sH4X8pu3ZnlH1cF2CXaskO+tjUE6POmB+EFLNKfm8dSnJOkWohjQ==",
+      "requires": {
+        "@abandonware/bluetooth-hci-socket": "^0.5.3-5",
+        "debug": "^4.1.1",
+        "napi-thread-safe-callback": "0.0.6",
+        "node-addon-api": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node-addon-api": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -2124,6 +2175,12 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true
+    },
     "acorn": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
@@ -2621,8 +2678,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2727,7 +2783,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2925,6 +2980,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "check-types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
+      "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
+    },
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -3081,8 +3141,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "confusing-browser-globals": {
       "version": "1.0.10",
@@ -4433,11 +4492,19 @@
         "universalify": "^1.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "optional": true,
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -4550,6 +4617,19 @@
         "pump": "^3.0.0"
       }
     },
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -4574,7 +4654,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4904,7 +4983,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -4913,6 +4991,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "optional": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "import-local": {
       "version": "3.0.2",
@@ -4979,7 +5066,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7445,7 +7531,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7454,6 +7539,33 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "optional": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "optional": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -7474,6 +7586,15 @@
             "is-plain-object": "^2.0.4"
           }
         }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "optional": true,
+      "requires": {
+        "minimist": "^1.2.5"
       }
     },
     "mkdirp-classic": {
@@ -7528,11 +7649,44 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
+    "napi-thread-safe-callback": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/napi-thread-safe-callback/-/napi-thread-safe-callback-0.0.6.tgz",
+      "integrity": "sha512-X7uHCOCdY4u0yamDxDrv3jF2NtYc8A1nvPzBQgvpoSX+WB3jAe2cVNsY448V1ucq7Whf9Wdy02HEUoLW5rJKWg=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "needle": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
+      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "optional": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "optional": true
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -7630,6 +7784,41 @@
         }
       }
     },
+    "node-pre-gyp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "optional": true
+        }
+      }
+    },
     "node-releases": {
       "version": "1.1.67",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
@@ -7640,6 +7829,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "optional": true,
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -7666,6 +7865,32 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "optional": true,
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "optional": true
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "optional": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -7863,11 +8088,26 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "optional": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "optional": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -7944,8 +8184,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -8582,6 +8821,38 @@
         "glob": "^7.1.3"
       }
     },
+    "rocket-nuimo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/rocket-nuimo/-/rocket-nuimo-0.5.1.tgz",
+      "integrity": "sha512-bpeMQKQzfzKsYiPy5j1/2m9Gg6/+7Rbjs8jCvEjz7G/lmn2T37o/ysqMJyyoVxh/TtqqQDTNwyOE+1cYGS3h/w==",
+      "requires": {
+        "@abandonware/noble": "^1.9.2-7",
+        "check-types": "^11.1",
+        "debug": "^4.1",
+        "tslib": "^1.11",
+        "weak-napi": "^1.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "rollup": {
       "version": "1.32.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
@@ -8845,8 +9116,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -8925,6 +9195,12 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "optional": true
+    },
     "saxes": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
@@ -8990,6 +9266,15 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "setimmediate-napi": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/setimmediate-napi/-/setimmediate-napi-1.0.6.tgz",
+      "integrity": "sha512-sdNXN15Av1jPXuSal4Mk4tEAKn0+8lfF9Z50/negaQMrAIO9c1qM0eiCh8fT6gctp0RiCObk+6/Xfn5RMGdZoA==",
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1",
+        "get-uv-event-loop-napi-h": "^1.0.5"
       }
     },
     "shebang-command": {
@@ -9558,6 +9843,29 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        }
+      }
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "optional": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "optional": true
         }
       }
     },
@@ -10236,6 +10544,48 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "usb": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-1.6.3.tgz",
+      "integrity": "sha512-23KYMjaWydACd8wgGKMQ4MNwFspAT6Xeim4/9Onqe5Rz/nMb4TM/WHL+qPT0KNFxzNKzAs63n1xQWGEtgaQ2uw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.4.0",
+        "nan": "2.13.2",
+        "prebuild-install": "^5.3.3"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "optional": true
+        },
+        "prebuild-install": {
+          "version": "5.3.6",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
+          "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
+    },
     "usb-detection": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/usb-detection/-/usb-detection-4.10.0.tgz",
@@ -10370,6 +10720,23 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "weak-napi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/weak-napi/-/weak-napi-1.0.3.tgz",
+      "integrity": "sha512-cyqeMaYA5qI7RoZKAKvIHwEROEKDNxK7jXj3u56nF2rGBh+HFyhYmBb1/wAN4RqzRmkYKVVKQyqHpBoJjqtGUA==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "node-addon-api": "^1.1.0",
+        "setimmediate-napi": "^1.0.3"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+        }
       }
     },
     "webidl-conversions": {

--- a/knob-ts/package.json
+++ b/knob-ts/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@svrooij/sonos": "^2.2.0",
     "node-hid": "^2.1.1",
+    "rocket-nuimo": "^0.5.1",
     "usb-detection": "^4.10.0"
   }
 }

--- a/knob-ts/src/index.ts
+++ b/knob-ts/src/index.ts
@@ -25,8 +25,12 @@ const sonos = new Sonos();
 nuimo.on(NuimoEvents.SINGLE_PRESS, () => sonos.togglePlay());
 nuimo.on(NuimoEvents.CLOCKWISE, () => sonos.volumeUp());
 nuimo.on(NuimoEvents.COUNTERCLOCKWISE, () => sonos.volumeDown());
-nuimo.on(NuimoEvents.SWIPE_RIGHT, () => sonos.next());
-nuimo.on(NuimoEvents.SWIPE_LEFT, () => sonos.previous());
+nuimo.on(NuimoEvents.SWIPE_RIGHT, () =>
+  sonos.next()?.then(() => nuimo.displayGlyph(NuimoGlyphs.NEXT))
+);
+nuimo.on(NuimoEvents.SWIPE_LEFT, () =>
+  sonos.previous()?.then(() => nuimo.displayGlyph(NuimoGlyphs.PREVIOUS))
+);
 
 // Map PowerMate Long Press to reconnect Nuimo if it disconnects (and pulse LED while connecting)
 powermate.on(PowerMateEvents.LONG_PRESS, () => nuimo.connect());

--- a/knob-ts/src/index.ts
+++ b/knob-ts/src/index.ts
@@ -24,21 +24,26 @@ nuimo.on(NuimoEvents.COUNTERCLOCKWISE, () => sonos.volumeDown());
 nuimo.on(NuimoEvents.SWIPE_RIGHT, () => sonos.next());
 nuimo.on(NuimoEvents.SWIPE_LEFT, () => sonos.previous());
 
+// Map PowerMate Long Press to reconnect Nuimo if it disconnects (and pulse LED while connecting)
+powermate.on(PowerMateEvents.LONG_PRESS, () => nuimo.connect());
+nuimo.on(NuimoEvents.DISCOVERY_STARTED, () =>
+  powermate.setLed({ isPulsing: true })
+);
+nuimo.on(NuimoEvents.DISCOVERY_FINISHED, () =>
+  powermate.setLed({ isPulsing: false })
+);
+
 // Map PowerMate inputs to Sonos functions
 powermate.on(PowerMateEvents.CLOCKWISE, () => sonos.volumeUp());
 powermate.on(PowerMateEvents.PRESS_CLOCKWISE, () => sonos.next());
 powermate.on(PowerMateEvents.COUNTERCLOCKWISE, () => sonos.volumeDown());
 powermate.on(PowerMateEvents.PRESS_COUNTERCLOCKWISE, () => sonos.previous());
 powermate.on(PowerMateEvents.SINGLE_PRESS, () => sonos.togglePlay());
-powermate.on(PowerMateEvents.LONG_PRESS, () => sonos.toggleGroup());
 powermate.on(PowerMateEvents.DOUBLE_PRESS, () => {});
 
 // Map Sonos state updates to PowerMate LED
 sonos.on(SonosEvents.PLAYING, () => powermate.setLed({ isOn: true }));
 sonos.on(SonosEvents.PAUSED, () => powermate.setLed({ isOn: false }));
-sonos.on(SonosEvents.GROUP_CHANGED, ({ isGrouped }) =>
-  powermate.setLed({ isOn: true, isPulsing: isGrouped })
-);
 
 // For development, uncomment
 // import repl from 'repl';

--- a/knob-ts/src/index.ts
+++ b/knob-ts/src/index.ts
@@ -18,7 +18,9 @@ const powermate = new PowerMate();
 const sonos = new Sonos();
 
 // Map Nuimo inputs to Sonos functions
-nuimo.on(NuimoEvents.SINGLE_PRESS, () => {});
+nuimo.on(NuimoEvents.SINGLE_PRESS, () => sonos.togglePlay());
+nuimo.on(NuimoEvents.CLOCKWISE, () => sonos.volumeUp());
+nuimo.on(NuimoEvents.COUNTERCLOCKWISE, () => sonos.volumeDown());
 
 // Map PowerMate inputs to Sonos functions
 powermate.on(PowerMateEvents.CLOCKWISE, () => sonos.volumeUp());

--- a/knob-ts/src/index.ts
+++ b/knob-ts/src/index.ts
@@ -5,14 +5,20 @@
  *
  * Supports:
  * - Griffin PowerMate (input)
+ * - Senic Nuimo (input)
  * - Sonos (output)
  */
 
 import { Sonos, EVENTS as SonosEvents } from './outputs/sonos';
 import { PowerMate, EVENTS as PowerMateEvents } from './inputs/powermate';
+import { Nuimo, EVENTS as NuimoEvents } from './inputs/nuimo';
 
+const nuimo = new Nuimo();
 const powermate = new PowerMate();
 const sonos = new Sonos();
+
+// Map Nuimo inputs to Sonos functions
+nuimo.on(NuimoEvents.SINGLE_PRESS, () => {});
 
 // Map PowerMate inputs to Sonos functions
 powermate.on(PowerMateEvents.CLOCKWISE, () => sonos.volumeUp());

--- a/knob-ts/src/index.ts
+++ b/knob-ts/src/index.ts
@@ -11,7 +11,11 @@
 
 import { Sonos, EVENTS as SonosEvents } from './outputs/sonos';
 import { PowerMate, EVENTS as PowerMateEvents } from './inputs/powermate';
-import { Nuimo, EVENTS as NuimoEvents } from './inputs/nuimo';
+import {
+  Nuimo,
+  EVENTS as NuimoEvents,
+  GLYPHS as NuimoGlyphs,
+} from './inputs/nuimo';
 
 const nuimo = new Nuimo();
 const powermate = new PowerMate();
@@ -41,9 +45,15 @@ powermate.on(PowerMateEvents.PRESS_COUNTERCLOCKWISE, () => sonos.previous());
 powermate.on(PowerMateEvents.SINGLE_PRESS, () => sonos.togglePlay());
 powermate.on(PowerMateEvents.DOUBLE_PRESS, () => {});
 
-// Map Sonos state updates to PowerMate LED
-sonos.on(SonosEvents.PLAYING, () => powermate.setLed({ isOn: true }));
-sonos.on(SonosEvents.PAUSED, () => powermate.setLed({ isOn: false }));
+// Map Sonos state updates to PowerMate LED and Nuimo screen
+sonos.on(SonosEvents.PLAYING, () => {
+  powermate.setLed({ isOn: true });
+  nuimo.displayGlyph(NuimoGlyphs.PLAY);
+});
+sonos.on(SonosEvents.PAUSED, () => {
+  powermate.setLed({ isOn: false });
+  nuimo.displayGlyph(NuimoGlyphs.PAUSE);
+});
 
 // For development, uncomment
 // import repl from 'repl';

--- a/knob-ts/src/index.ts
+++ b/knob-ts/src/index.ts
@@ -22,7 +22,13 @@ const powermate = new PowerMate();
 const sonos = new Sonos();
 
 // Map Nuimo inputs to Sonos functions
-nuimo.on(NuimoEvents.SINGLE_PRESS, () => sonos.togglePlay());
+nuimo.on(NuimoEvents.SINGLE_PRESS, () => {
+  if (sonos.isPlaying) {
+    sonos.pause()?.then(() => nuimo.displayGlyph(NuimoGlyphs.PAUSE));
+  } else {
+    sonos.play()?.then(() => nuimo.displayGlyph(NuimoGlyphs.PLAY));
+  }
+});
 nuimo.on(NuimoEvents.CLOCKWISE, () => sonos.volumeUp());
 nuimo.on(NuimoEvents.COUNTERCLOCKWISE, () => sonos.volumeDown());
 nuimo.on(NuimoEvents.SWIPE_RIGHT, () =>
@@ -50,14 +56,8 @@ powermate.on(PowerMateEvents.SINGLE_PRESS, () => sonos.togglePlay());
 powermate.on(PowerMateEvents.DOUBLE_PRESS, () => {});
 
 // Map Sonos state updates to PowerMate LED and Nuimo screen
-sonos.on(SonosEvents.PLAYING, () => {
-  powermate.setLed({ isOn: true });
-  nuimo.displayGlyph(NuimoGlyphs.PLAY);
-});
-sonos.on(SonosEvents.PAUSED, () => {
-  powermate.setLed({ isOn: false });
-  nuimo.displayGlyph(NuimoGlyphs.PAUSE);
-});
+sonos.on(SonosEvents.PLAYING, () => powermate.setLed({ isOn: true }));
+sonos.on(SonosEvents.PAUSED, () => powermate.setLed({ isOn: false }));
 
 // For development, uncomment
 // import repl from 'repl';

--- a/knob-ts/src/index.ts
+++ b/knob-ts/src/index.ts
@@ -21,6 +21,8 @@ const sonos = new Sonos();
 nuimo.on(NuimoEvents.SINGLE_PRESS, () => sonos.togglePlay());
 nuimo.on(NuimoEvents.CLOCKWISE, () => sonos.volumeUp());
 nuimo.on(NuimoEvents.COUNTERCLOCKWISE, () => sonos.volumeDown());
+nuimo.on(NuimoEvents.SWIPE_RIGHT, () => sonos.next());
+nuimo.on(NuimoEvents.SWIPE_LEFT, () => sonos.previous());
 
 // Map PowerMate inputs to Sonos functions
 powermate.on(PowerMateEvents.CLOCKWISE, () => sonos.volumeUp());

--- a/knob-ts/src/inputs/nuimo.ts
+++ b/knob-ts/src/inputs/nuimo.ts
@@ -23,6 +23,21 @@ const setupDebug = (nuimo: Nuimo) => {
   }
 };
 
+/** Configuration for Nuimo Sensitivity */
+const SENSITIVITY = {
+  /** Number of milliseconds for button to be held to trigger a "long press" */
+  LONG_PRESS_MS: 1000,
+  /** Number of milliseconds between presses to trigger a "double press" */
+  DOUBLE_PRESS_MS: 300,
+};
+
+/** Timers for long/double press events */
+type PressTimer = {
+  timer: ReturnType<typeof setTimeout> | undefined;
+  isRunning: boolean;
+  PRESS_MS: number;
+};
+
 const manager = DeviceDiscoveryManager.defaultManager;
 
 export const startDiscovery = async (): Promise<
@@ -50,14 +65,81 @@ export const startDiscovery = async (): Promise<
 
 export class Nuimo extends EventEmitter {
   device: NuimoControlDevice | undefined;
+  isPressed: boolean;
+  longPress: PressTimer;
+  doublePress: PressTimer;
 
   constructor() {
     super();
     setupDebug(this);
 
+    this.isPressed = false;
+    this.longPress = {
+      timer: undefined,
+      isRunning: false,
+      PRESS_MS: SENSITIVITY.LONG_PRESS_MS,
+    };
+    this.doublePress = {
+      timer: undefined,
+      isRunning: false,
+      PRESS_MS: SENSITIVITY.DOUBLE_PRESS_MS,
+    };
+
     // Find and connect to the Nuimo
     startDiscovery().then(device => {
       this.device = device;
+
+      // Set up presses
+      this.device?.on('selectDown', () => this.computePress(1));
+      this.device?.on('selectUp', () => this.computePress(0));
     });
+  }
+
+  /**
+   * Compute press inputs and emit events
+   *
+   * @param pressInput - boolean 0 or 1 for "up" or "down"
+   */
+  computePress(pressInput: 0 | 1) {
+    const isPressed = Boolean(pressInput);
+    const buttonDown = isPressed; // for readability down below
+    const buttonUp = !isPressed; // for readability down below
+
+    // If there is a change from what is currently stored:
+    if (isPressed != this.isPressed) {
+      this.isPressed = isPressed;
+
+      if (buttonDown) {
+        // Start LONG_PRESS timer
+        this.longPress.isRunning = true;
+        this.longPress.timer = setTimeout(() => {
+          this.longPress.isRunning = false;
+          this.emit(EVENTS.LONG_PRESS);
+        }, this.longPress.PRESS_MS);
+      }
+
+      if (buttonUp) {
+        if (this.longPress.isRunning) {
+          // Check if we're within a DOUBLE_PRESS timeout
+          if (this.doublePress.isRunning) {
+            // If we had a second press within a DOUBLE_PRESS timeout, it's a DOUBLE_PRESS
+            this.doublePress.isRunning = false;
+            clearTimeout(this.doublePress.timer as NodeJS.Timeout);
+            this.emit(EVENTS.DOUBLE_PRESS);
+          } else {
+            // If we aren't already in a DOUBLE_PRESS timeout, set one
+            this.doublePress.isRunning = true;
+            this.doublePress.timer = setTimeout(() => {
+              // If nothing else happens before the DOUBLE_PRESS timeout finishes, it's a SINGLE_PRESS
+              this.doublePress.isRunning = false;
+              this.emit(EVENTS.SINGLE_PRESS);
+            }, this.doublePress.PRESS_MS);
+          }
+        }
+
+        // Clear LONG_PRESS timer when released
+        clearTimeout(this.longPress.timer as NodeJS.Timeout);
+      }
+    }
   }
 }

--- a/knob-ts/src/inputs/nuimo.ts
+++ b/knob-ts/src/inputs/nuimo.ts
@@ -1,6 +1,13 @@
 import Debug from 'debug';
 import { EventEmitter } from 'events';
-import { DeviceDiscoveryManager, NuimoControlDevice } from 'rocket-nuimo';
+import {
+  DeviceDiscoveryManager,
+  DisplayGlyphOptions,
+  Glyph,
+  NuimoControlDevice,
+  pauseGlyph,
+  playGlyph,
+} from 'rocket-nuimo';
 
 /** Events for Nuimo discovery, connect, select/tap and rotation */
 export const EVENTS: { [eventName: string]: string } = {
@@ -19,6 +26,11 @@ export const EVENTS: { [eventName: string]: string } = {
   SWIPE_RIGHT: 'swipeRight',
   SWIPE_UP: 'swipeUp',
   SWIPE_DOWN: 'swipeDown',
+};
+
+export const GLYPHS: { [glyphName: string]: Glyph } = {
+  PLAY: playGlyph,
+  PAUSE: pauseGlyph,
 };
 
 /** Shortcut to Debug('knob-ts:nuimo')() */
@@ -164,6 +176,12 @@ export class Nuimo extends EventEmitter {
         // Emit failure
         this.emit(EVENTS.DISCOVERY_FINISHED, { success: false });
       });
+  }
+  displayGlyph(
+    glyph: Glyph,
+    options: DisplayGlyphOptions = { timeoutMs: 1000 }
+  ) {
+    this.device?.displayGlyph(glyph, options);
   }
 
   /**

--- a/knob-ts/src/inputs/nuimo.ts
+++ b/knob-ts/src/inputs/nuimo.ts
@@ -11,6 +11,10 @@ export const EVENTS: { [eventName: string]: string } = {
   COUNTERCLOCKWISE: 'counterclockwise',
   PRESS_CLOCKWISE: 'pressClockwise',
   PRESS_COUNTERCLOCKWISE: 'pressCounterclockwise',
+  SWIPE_LEFT: 'swipeLeft',
+  SWIPE_RIGHT: 'swipeRight',
+  SWIPE_UP: 'swipeUp',
+  SWIPE_DOWN: 'swipeDown',
 };
 
 /** Shortcut to Debug('knob-ts:nuimo')() */
@@ -126,6 +130,11 @@ export class Nuimo extends EventEmitter {
           this.computeRotation(delta);
         }
       });
+
+      // Set up swipes
+      this.device?.on('swipe', direction =>
+        this.emit(EVENTS[`SWIPE_${direction.toUpperCase()}`])
+      );
     });
   }
 

--- a/knob-ts/src/inputs/nuimo.ts
+++ b/knob-ts/src/inputs/nuimo.ts
@@ -4,9 +4,11 @@ import {
   DeviceDiscoveryManager,
   DisplayGlyphOptions,
   Glyph,
+  leftGlyph,
   NuimoControlDevice,
   pauseGlyph,
   playGlyph,
+  rightGlyph,
 } from 'rocket-nuimo';
 
 /** Events for Nuimo discovery, connect, select/tap and rotation */
@@ -31,6 +33,8 @@ export const EVENTS: { [eventName: string]: string } = {
 export const GLYPHS: { [glyphName: string]: Glyph } = {
   PLAY: playGlyph,
   PAUSE: pauseGlyph,
+  NEXT: rightGlyph,
+  PREVIOUS: leftGlyph,
 };
 
 /** Shortcut to Debug('knob-ts:nuimo')() */

--- a/knob-ts/src/inputs/nuimo.ts
+++ b/knob-ts/src/inputs/nuimo.ts
@@ -63,7 +63,7 @@ const manager = DeviceDiscoveryManager.defaultManager;
 
 const startDiscovery = async (): Promise<NuimoControlDevice | undefined> => {
   debug('startDiscovery: Starting Nuimo device discovery');
-  const session = manager.startDiscoverySession();
+  const session = manager.startDiscoverySession({ timeoutMs: 60 * 1000 });
   debug('startDiscovery: Waiting for device...');
   const device = await session.waitForFirstDevice();
   debug('startDiscovery: Found device: %o', { id: device.id });

--- a/knob-ts/src/inputs/nuimo.ts
+++ b/knob-ts/src/inputs/nuimo.ts
@@ -1,0 +1,63 @@
+import Debug from 'debug';
+import { EventEmitter } from 'events';
+import { DeviceDiscoveryManager, NuimoControlDevice } from 'rocket-nuimo';
+
+/** Events for Nuimo select/tap and rotation */
+export const EVENTS: { [eventName: string]: string } = {
+  SINGLE_PRESS: 'singlePress',
+  DOUBLE_PRESS: 'doublePress',
+  LONG_PRESS: 'longPress',
+  CLOCKWISE: 'clockwise',
+  COUNTERCLOCKWISE: 'counterclockwise',
+  PRESS_CLOCKWISE: 'pressClockwise',
+  PRESS_COUNTERCLOCKWISE: 'pressCounterclockwise',
+};
+
+/** Shortcut to Debug('knob-ts:nuimo')() */
+const debug = Debug('knob-ts:nuimo');
+
+/** Debugger for events */
+const setupDebug = (nuimo: Nuimo) => {
+  for (const event in EVENTS) {
+    nuimo.on(EVENTS[event], data => debug({ event, data }));
+  }
+};
+
+const manager = DeviceDiscoveryManager.defaultManager;
+
+export const startDiscovery = async (): Promise<
+  NuimoControlDevice | undefined
+> => {
+  debug('startDiscovery: Starting Nuimo device discovery');
+  const session = manager.startDiscoverySession();
+  debug('startDiscovery: Waiting for device...');
+  const device = await session.waitForFirstDevice();
+  debug(`startDiscovery: Found device: ${device.id}`);
+  debug('startDiscovery: Connecting...');
+  if (await device.connect()) {
+    debug('startDiscovery: Connected to device: %o', {
+      batteryLevel: device.batteryLevel,
+    });
+    device.on('disconnect', () =>
+      debug('startDiscovery: Disconnected from device')
+    );
+    return device;
+  } else {
+    debug('startDiscovery: Something went wrong');
+    return;
+  }
+};
+
+export class Nuimo extends EventEmitter {
+  device: NuimoControlDevice | undefined;
+
+  constructor() {
+    super();
+    setupDebug(this);
+
+    // Find and connect to the Nuimo
+    startDiscovery().then(device => {
+      this.device = device;
+    });
+  }
+}

--- a/knob-ts/src/inputs/powermate.ts
+++ b/knob-ts/src/inputs/powermate.ts
@@ -158,9 +158,15 @@ export class PowerMate extends EventEmitter {
   /**
    * Set LED information on PowerMate and update internal ledState
    *
-   * @param ledState - the `LedState` information with which to update the device
+   * @param ledState - the `LedState` information with which to update the device (can accept partial updates)
    */
   setLed(ledState: LedState) {
+    // Merge with existing ledState so we can send partial updates (like only isPulsing or only isOn)
+    ledState = Object.assign(
+      { isOn: this.ledState.isOn, isPulsing: this.ledState.isPulsing },
+      ledState
+    );
+
     // NB: I found these definitions in sandeepmistry/node-powermate
     const commands = {
       setBrightness: 0x01,

--- a/knob-ts/src/outputs/sonos.ts
+++ b/knob-ts/src/outputs/sonos.ts
@@ -115,6 +115,16 @@ export class Sonos extends EventEmitter {
     this.PRIMARY_DEVICE?.TogglePlayback();
   }
 
+  /** Play */
+  play() {
+    return this.PRIMARY_DEVICE?.Play();
+  }
+
+  /** Pause */
+  pause() {
+    return this.PRIMARY_DEVICE?.Pause();
+  }
+
   /** Next track */
   next() {
     return this.PRIMARY_DEVICE?.Next();

--- a/knob-ts/src/outputs/sonos.ts
+++ b/knob-ts/src/outputs/sonos.ts
@@ -117,12 +117,12 @@ export class Sonos extends EventEmitter {
 
   /** Next track */
   next() {
-    this.PRIMARY_DEVICE?.Next();
+    return this.PRIMARY_DEVICE?.Next();
   }
 
   /** Previous track */
   previous() {
-    this.PRIMARY_DEVICE?.Previous();
+    return this.PRIMARY_DEVICE?.Previous();
   }
 
   /** Volume down for current group */

--- a/knob-ts/test/nuimo.test.ts
+++ b/knob-ts/test/nuimo.test.ts
@@ -1,0 +1,11 @@
+// import { Nuimo } from '../src/inputs/nuimo';
+
+xdescribe('Nuimo', () => {
+  it('creates a new Nuimo', () => {
+    /**
+     * @fixme How do you mock a Nuimo device? It needs to be paired etc.
+     */
+    // const nuimo = new Nuimo();
+    // expect(nuimo).toBeDefined();
+  });
+});


### PR DESCRIPTION
> Another late night, stream-of-consciousness PR ... remember this is for me, not for you

This is the first attempt at adding the Nuimo input to knob-ts

A crude video of it kind of working, once, (running on the actual Media Cube):


https://user-images.githubusercontent.com/3157928/103335290-8d120f00-4a42-11eb-94d9-04c04f636a5b.mp4

It has unpaired, gotten out of sync with Sonos, sent double-presses (?) and even made it so the PowerMate doesn't behave correctly since taking this video, so I need to figure that out...

# Issues I'm still seeing:

### Double(/triple) presses don't work like I expected

I'm discovering that something about the latency on "select" (press) events is bad on the Nuimo and my existing "double press" logic didn't carry over from the PowerMate because the Nuimo doesn't send presses as reliably... 
  - It doesn't register all the down/up's of each press, it seems like there's a lag - it doesn't register the second press unless it's considerably slower, but even then it's not registering both down/up's sometimes
![image](https://user-images.githubusercontent.com/3157928/103334843-f002a680-4a40-11eb-9ea0-c62c41605f7c.png)
(see the double "selectUp" events there - this is what happens when I try to double-click it)

### Rotation gets clamped by default

Rotation events only fire within a range of values... this behavior is confusing after working with the PowerMate - it keeps track of how far you've rotated (`rotation:` value in the event) and adds/subtracts the `delta` value until it hits the range's min/max - clever, but not necessary for me.

The clamping [happens in the `rocket-nuimo` library](https://github.com/happycodelucky/rocket-nuimo-node/blob/main/src/model/nuimo-control-device.ts#L395-L410) and there isn't an official way to override it, but I have some ideas:

- Could set a really wide range and just expect that I'll never hit the actual number? `device.setRotationRange(-10000,10000,0)`? 
- Or just call `this.device.rotation=0` after every `computeRotation()` call (yep. just do that, it gets around it, [referenced docs here](https://github.com/happycodelucky/rocket-nuimo-node/blob/main/docs/api/classes/nuimocontroldevice.md#rotation) to find that there's a setter for this)

I considered working _with_ this and adding something that updates the Sonos's current volume level in a sort of two-way bind situation, but that seems like a bad idea and overly complicated

### The Nuimo goes to sleep to save battery

The Nuimo turns off after a certain amount of time, and a "press" (selectDown/selectUp) seems to be the most reliable thing to wake it up, so I might need to add a timeout where the first press after a long-ish timeout doesn't emit an press event (so that practically, it doesn't stop the music when I'm trying to wake the device up)

### I need to add LED feedback to Nuimo

I haven't done anything to add feedback from the input events on the Nuimo ... this would help a lot to know whether the input has actually registered

### Debouncer _AND_ minimum delta on rotation feels weird
There are two different mechanisms that are throttling the rotation events right now:
- a debouncer, which prevents the event from being sent more than once every 200ms
- a minimum delta for the rotation (`SENSITIVITY.ROTATION_MINIMUM_DELTA`), which disregards small or slow movements in the knob's rotation

The combination of the two means you can't just "turn the knob slowly" to adjust it carefully, since the tiny rotations don't register if they're below the delta, and the debouncer can get in the way of events being sent too frequently if you're turning slowly but at a sustained rate... hard to explain but definitely a "feel" thing that I want to fix

### Re-pairing the Nuimo if(/when, really) it gets disconnected

I might need to add a method to the Nuimo class that lets me restart the discovery and re-pair the device ... If I expose this as a class method, I could conceivably tuck that function into the PowerMate's "long press" or something so I could start the re-pairing process without having to open up the Terminal and SSH to the box and do it by hand... In any case, I don't trust the Nuimo to stay connected nicely so I want to mitigate that if possible