### PR TITLE
bonk: Add Layer 2

### DIFF
--- a/bonk/README.md
+++ b/bonk/README.md
@@ -24,6 +24,28 @@ It will map inputs and outputs from the following devices:
 | press + counterclockwise | Sonos Group Volume Down | Sonos Group Volume Up |
 | swipe right              | _(not supported)_       | Sonos Next Track      |
 | swipe left               | _(not supported)_       | Sonos Previous Track  |
+| long press               | Enter Layer 2           | Enter Layer 2         |
+
+### Layer 2
+
+**PowerMate: (indicated by pulsing)**
+
+- Clockwise/counterclockwise: Forward and back between functions
+- Press: Select function
+  - Function 1: (indicated by pulse `.`): Re-pair Nuimo
+  - Function 2: (indicated by pulse `..`): Toggle Sonos Group
+  - Function 3: (indicated by pulse `...`): _(not supported)_
+- Long press: Back to Layer 1
+
+**Nuimo: (indicated by on-screen icons)**
+
+- Clockwise/counterclockwise: Forward and back between functions
+- Press: Select function
+  - Function 1: (indicated by icon): Nuimo Battery Level
+  - Function 2: (indicated by icon): Toggle Sonos Group
+  - Function 3: (indicated by icon): ? (Playlists?)
+  - Function 4: (indicated by icon): ? (Radio?)
+- Long press: Back to Layer 1
 
 ## Setup
 


### PR DESCRIPTION
> This is me reopening #7 after renaming the library

This is gonna be how we add secondary functionality to input devices (beyond the default media controls)

I'm tentatively using a "layers" metaphor and calling this set of features "Layer 2"

- Long press will enter Layer 2 on either device
  - PowerMate will pulse while in Layer 2; pulse patterns to indicate currently-selected function
    - F1: re-pair Nuimo
    - F2: toggle Sonos grouping
    - F3: (maybe not supported?)
  - Nuimo will show on-screen glyphs to indicate the currently-selected function
    - F1: battery level
    - F2: toggle Sonos grouping
    - F3: playlists?
    - F4: radio / Sonos favorites?
    - ... are there more? 
 
Functions that Layer 2 can accommodate include (also listed above):
- toggling Sonos grouping
- re-pairing the Nuimo to Bluetooth (PowerMate only)
- selecting specified playlists?
- selecting specified radio?
- maybe Hue light control too?

Just off the top of my head, I'm going to need:
- [ ] defined pulse patterns on PowerMate (need some way to indicate which function we're on when we're selecting)
- [ ] glyphs for each function on Nuimo (can just be digits for now, but would be nice if they were elegant)
- [ ] extra shortcuts in Sonos for playlists/favorites/whatever
- [ ] blink(1) support? (this might also be where blink(1) support is added because I could use that to indicate Layer 2 functions for PowerMate since both devices are physically near each other on the cabinet itself)