### PR TITLE
Bonk: Fix PowerMate pulsing LED issue

### DIFF
--- a/bonk/package.json
+++ b/bonk/package.json
@@ -17,6 +17,7 @@
     "lint": "tsdx lint",
     "prepare": "tsdx build",
     "pm2:start": "pm2 start pm2.config.json",
+    "pm2:restart": "pm2 restart pm2.config.json",
     "pm2:stop": "pm2 stop pm2.config.json",
     "pm2:debug": "pm2 startOrReload pm2.config.json --env debug",
     "pm2:logs": "pm2 logs bonk",

--- a/bonk/pm2.config.json
+++ b/bonk/pm2.config.json
@@ -2,7 +2,6 @@
   "name": "bonk",
   "script": "dist/index.js",
   "pmx": false,
-  "watch": true,
   "env": {
     "SONOS_LISTENER_HOST": "10.0.1.10",
     "DEBUG": "bonk:*"

--- a/bonk/pm2.config.json
+++ b/bonk/pm2.config.json
@@ -2,6 +2,7 @@
   "name": "bonk",
   "script": "dist/index.js",
   "pmx": false,
+  "watch": true,
   "env": {
     "SONOS_LISTENER_HOST": "10.0.1.10",
     "DEBUG": "bonk:*"

--- a/bonk/src/devices/powermate/device.ts
+++ b/bonk/src/devices/powermate/device.ts
@@ -233,13 +233,11 @@ export class PowerMate extends EventEmitter {
      */
     const pressInput = data[0] as 0 | 1;
     const rotationInput = data[1] as number;
-
-    // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - write-only... maybe this will fix the pulsing problem
-    // const ledInput: LedState = {
-    //   isOn: Boolean(data[3]),
-    //   isPulsing: data[4] & 0x4 ? true : false, // ? Sure
-    //   // pulseSpeed: figureOut(data[5]) // TODO: Add pulseSpeed
-    // };
+    const ledInput: LedState = {
+      isOn: Boolean(data[3]),
+      isPulsing: data[4] & 0x4 ? true : false, // ? Sure
+      // pulseSpeed: figureOut(data[5]) // TODO: Add pulseSpeed
+    };
 
     /**
      * Compute press inputs and emit events
@@ -360,15 +358,20 @@ export class PowerMate extends EventEmitter {
     };
 
     /** Compute LED status and update internal ledState */
-    // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - write-only... maybe this will fix the pulsing problem
-    // const computeLed = (ledState: LedState) => (this.ledState = ledState);
+    const computeLed = (ledState: LedState) => {
+      // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - should possibly think of hardware LED state as "write-only"
+      // this.ledState = ledState
+      debug('computeLed experiment: %O', {
+        ledState,
+        rawData4Value: data[4],
+        bitwiseANDData4Value: data[4] & 0x4,
+      });
+    };
 
     // Compute inputs and emit events
     computePress(pressInput);
     computeRotation(rotationInput);
-
-    // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - write-only... maybe this will fix the pulsing problem
-    // computeLed(ledInput);
+    computeLed(ledInput);
 
     // Restart the read loop
     this.hid?.read(this.interpretData.bind(this));

--- a/bonk/src/devices/powermate/device.ts
+++ b/bonk/src/devices/powermate/device.ts
@@ -233,11 +233,13 @@ export class PowerMate extends EventEmitter {
      */
     const pressInput = data[0] as 0 | 1;
     const rotationInput = data[1] as number;
-    const ledInput: LedState = {
-      isOn: Boolean(data[3]),
-      isPulsing: data[4] & 0x4 ? true : false, // ? Sure
-      // pulseSpeed: figureOut(data[5]) // TODO: Add pulseSpeed
-    };
+
+    // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - write-only... maybe this will fix the pulsing problem
+    // const ledInput: LedState = {
+    //   isOn: Boolean(data[3]),
+    //   isPulsing: data[4] & 0x4 ? true : false, // ? Sure
+    //   // pulseSpeed: figureOut(data[5]) // TODO: Add pulseSpeed
+    // };
 
     /**
      * Compute press inputs and emit events
@@ -358,12 +360,15 @@ export class PowerMate extends EventEmitter {
     };
 
     /** Compute LED status and update internal ledState */
-    const computeLed = (ledState: LedState) => (this.ledState = ledState);
+    // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - write-only... maybe this will fix the pulsing problem
+    // const computeLed = (ledState: LedState) => (this.ledState = ledState);
 
     // Compute inputs and emit events
     computePress(pressInput);
     computeRotation(rotationInput);
-    computeLed(ledInput);
+
+    // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - write-only... maybe this will fix the pulsing problem
+    // computeLed(ledInput);
 
     // Restart the read loop
     this.hid?.read(this.interpretData.bind(this));

--- a/bonk/src/devices/powermate/device.ts
+++ b/bonk/src/devices/powermate/device.ts
@@ -358,15 +358,7 @@ export class PowerMate extends EventEmitter {
     };
 
     /** Compute LED status and update internal ledState */
-    const computeLed = (ledState: LedState) => {
-      // 🧪 Experiment: turning this off so the internal PowerMate ledState doesn't get overwritten on reads - should possibly think of hardware LED state as "write-only"
-      // this.ledState = ledState
-      debug('computeLed experiment: %O', {
-        ledState,
-        rawData4Value: data[4],
-        bitwiseANDData4Value: data[4] & 0x4,
-      });
-    };
+    const computeLed = (ledState: LedState) => (this.ledState = ledState);
 
     // Compute inputs and emit events
     computePress(pressInput);

--- a/bonk/src/devices/powermate/device.ts
+++ b/bonk/src/devices/powermate/device.ts
@@ -235,7 +235,8 @@ export class PowerMate extends EventEmitter {
     const rotationInput = data[1] as number;
     const ledInput: LedState = {
       isOn: Boolean(data[3]),
-      isPulsing: data[4] & 0x4 ? true : false, // ? Sure
+      // 🧪 Experiment: turning this off so the internal PowerMate ledState.isPulsing doesn't get overwritten on reads (isPulsing uses bad logic to set itself)
+      // isPulsing: data[4] & 0x4 ? true : false, // This logic is wrong; this gets set to true sometimes even when the device isn't pulsing
       // pulseSpeed: figureOut(data[5]) // TODO: Add pulseSpeed
     };
 


### PR DESCRIPTION
This is an attempt to fix an issue I've found where the LED starts pulsing for no apparent reason (I didn't trigger it in the app by triggering Nuimo reconnect with long press, etc)

I'm not entirely sure why I was reading the LED state in the past anyway, it was just data that came back on the `read` so I assumed I needed to do something with it, but that assumption may be incorrect 

I can manage the LED state in the device's (class)'s state rather than rely on whatever the actual hardware does internally (which I don't entirely understand anyway)