### PR TITLE
bonk: Fix Debouncers

### DIFF
--- a/bonk/src/devices/nuimo/device.ts
+++ b/bonk/src/devices/nuimo/device.ts
@@ -25,8 +25,6 @@ const sensitivity = {
   LONG_PRESS_MS: 1000,
   /** Debounce "wait" milliseconds for rotation inputs to alter the "sensitivity" of the knob rotation inputs. A higher value here means it takes more turning to trigger the inputs */
   ROTATION_WAIT_MS: 100,
-  /** Debounce "wait" milliseconds for press rotation inputs. Press rotation should be even less sensitive than regular rotation inputs. */
-  PRESS_ROTATION_WAIT_MS: 100,
   /** Minimum delta to register as a rotation event. The Nuimo is very sensitive and sends pretty precise rotation signals, so this filters out anything outside of a threshold */
   ROTATION_MINIMUM_DELTA: 0.005,
 };
@@ -57,7 +55,6 @@ export class Nuimo extends EventEmitter {
   isPressed: boolean;
   private longPress: PressTimer;
   private rotationDebouncer: Debouncer;
-  private pressRotationDebouncer: Debouncer;
 
   constructor() {
     super();
@@ -75,11 +72,6 @@ export class Nuimo extends EventEmitter {
       timer: undefined,
       isReady: true,
       WAIT_MS: sensitivity.ROTATION_WAIT_MS,
-    };
-    this.pressRotationDebouncer = {
-      timer: undefined,
-      isReady: true,
-      WAIT_MS: sensitivity.PRESS_ROTATION_WAIT_MS,
     };
 
     // Find and connect to the Nuimo
@@ -204,9 +196,7 @@ export class Nuimo extends EventEmitter {
       withDebouncer(this.rotationDebouncer, () => {
         if (delta < 0) {
           this.isPressed
-            ? withDebouncer(this.pressRotationDebouncer, () =>
-                this.emit(NuimoEvents.PRESS_COUNTERCLOCKWISE, { delta })
-              )
+            ? this.emit(NuimoEvents.PRESS_COUNTERCLOCKWISE, { delta })
             : this.emit(NuimoEvents.COUNTERCLOCKWISE, {
                 delta,
               });
@@ -214,9 +204,7 @@ export class Nuimo extends EventEmitter {
           if (this.device) this.device.rotation = 0;
         } else {
           this.isPressed
-            ? withDebouncer(this.pressRotationDebouncer, () =>
-                this.emit(NuimoEvents.PRESS_CLOCKWISE, { delta })
-              )
+            ? this.emit(NuimoEvents.PRESS_CLOCKWISE, { delta })
             : this.emit(NuimoEvents.CLOCKWISE, { delta });
           // Reset device.rotation each time because the library has a "clamp" built into the rotation (min/max) and I don't care about it
           if (this.device) this.device.rotation = 0;

--- a/bonk/src/devices/nuimo/device.ts
+++ b/bonk/src/devices/nuimo/device.ts
@@ -201,8 +201,7 @@ export class Nuimo extends EventEmitter {
       this.longPress.isRunning = false;
 
       // Use debouncer
-      this.rotationDebouncer.isReady = false;
-      this.rotationDebouncer.timer = setTimeout(() => {
+      withDebouncer(this.rotationDebouncer, () => {
         if (delta < 0) {
           this.isPressed
             ? withDebouncer(this.pressRotationDebouncer, () =>
@@ -222,9 +221,7 @@ export class Nuimo extends EventEmitter {
           // Reset device.rotation each time because the library has a "clamp" built into the rotation (min/max) and I don't care about it
           if (this.device) this.device.rotation = 0;
         }
-        // Reset debouncer "isReady" flag for next input
-        this.rotationDebouncer.isReady = true;
-      }, this.rotationDebouncer.WAIT_MS);
+      });
     }
   }
 }

--- a/bonk/src/devices/nuimo/device.ts
+++ b/bonk/src/devices/nuimo/device.ts
@@ -131,7 +131,9 @@ export class Nuimo extends EventEmitter {
         // Set up disconnect behavior
         this.device?.on('disconnect', () => {
           this.device?.removeAllListeners();
-          this.emit(NuimoEvents.DEVICE_DISCONNECTED, { id: this.device?.id });
+          this.emit(NuimoEvents.DEVICE_DISCONNECTED, {
+            id: this.device?.id,
+          });
         });
 
         // Emit success
@@ -203,10 +205,8 @@ export class Nuimo extends EventEmitter {
       this.rotationDebouncer.timer = setTimeout(() => {
         if (delta < 0) {
           this.isPressed
-            ? this.emitWithDebouncer(
-                NuimoEvents.PRESS_COUNTERCLOCKWISE,
-                { delta },
-                this.pressRotationDebouncer
+            ? this.withDebouncer(this.pressRotationDebouncer, () =>
+                this.emit(NuimoEvents.PRESS_COUNTERCLOCKWISE, { delta })
               )
             : this.emit(NuimoEvents.COUNTERCLOCKWISE, {
                 delta,
@@ -215,10 +215,8 @@ export class Nuimo extends EventEmitter {
           if (this.device) this.device.rotation = 0;
         } else {
           this.isPressed
-            ? this.emitWithDebouncer(
-                NuimoEvents.PRESS_CLOCKWISE,
-                { delta },
-                this.pressRotationDebouncer
+            ? this.withDebouncer(this.pressRotationDebouncer, () =>
+                this.emit(NuimoEvents.PRESS_CLOCKWISE, { delta })
               )
             : this.emit(NuimoEvents.CLOCKWISE, { delta });
           // Reset device.rotation each time because the library has a "clamp" built into the rotation (min/max) and I don't care about it
@@ -231,15 +229,14 @@ export class Nuimo extends EventEmitter {
   }
 
   /**
-   * emitWithDebouncer
+   * withDebouncer
    *
-   * @param event The event to emit when the debounce is ready
-   * @param data The data to send along with the event emitter
    * @param debouncer The `Debouncer` object with `timer`, `isReady`, and `WAIT_MS`
+   * @param fn The function to call when the debouncer is ready
    */
-  private emitWithDebouncer(event: string, data: {}, debouncer: Debouncer) {
+  private withDebouncer(debouncer: Debouncer, fn: () => void) {
     if (debouncer.isReady) {
-      this.emit(event, { data });
+      fn();
     }
     // Set up debouncer for future events
     debouncer.isReady = false;

--- a/bonk/src/devices/nuimo/device.ts
+++ b/bonk/src/devices/nuimo/device.ts
@@ -6,7 +6,7 @@ import {
   Glyph,
   NuimoControlDevice,
 } from 'rocket-nuimo';
-import { Debouncer, PressTimer } from '../utils';
+import { Debouncer, PressTimer, withDebouncer } from '../utils';
 import { NuimoEvents } from './events';
 
 /** Shortcut to Debug('bonk:nuimo')() */
@@ -205,7 +205,7 @@ export class Nuimo extends EventEmitter {
       this.rotationDebouncer.timer = setTimeout(() => {
         if (delta < 0) {
           this.isPressed
-            ? this.withDebouncer(this.pressRotationDebouncer, () =>
+            ? withDebouncer(this.pressRotationDebouncer, () =>
                 this.emit(NuimoEvents.PRESS_COUNTERCLOCKWISE, { delta })
               )
             : this.emit(NuimoEvents.COUNTERCLOCKWISE, {
@@ -215,7 +215,7 @@ export class Nuimo extends EventEmitter {
           if (this.device) this.device.rotation = 0;
         } else {
           this.isPressed
-            ? this.withDebouncer(this.pressRotationDebouncer, () =>
+            ? withDebouncer(this.pressRotationDebouncer, () =>
                 this.emit(NuimoEvents.PRESS_CLOCKWISE, { delta })
               )
             : this.emit(NuimoEvents.CLOCKWISE, { delta });
@@ -226,22 +226,5 @@ export class Nuimo extends EventEmitter {
         this.rotationDebouncer.isReady = true;
       }, this.rotationDebouncer.WAIT_MS);
     }
-  }
-
-  /**
-   * withDebouncer
-   *
-   * @param debouncer The `Debouncer` object with `timer`, `isReady`, and `WAIT_MS`
-   * @param fn The function to call when the debouncer is ready
-   */
-  private withDebouncer(debouncer: Debouncer, fn: () => void) {
-    if (debouncer.isReady) {
-      fn();
-    }
-    // Set up debouncer for future events
-    debouncer.isReady = false;
-    debouncer.timer = setTimeout(() => {
-      debouncer.isReady = true;
-    }, debouncer.WAIT_MS);
   }
 }

--- a/bonk/src/devices/powermate/device.ts
+++ b/bonk/src/devices/powermate/device.ts
@@ -317,8 +317,7 @@ export class PowerMate extends EventEmitter {
         this.longPress.isRunning = false;
 
         // Use debouncer
-        this.rotationDebouncer.isReady = false;
-        this.rotationDebouncer.timer = setTimeout(() => {
+        withDebouncer(this.rotationDebouncer, () => {
           if (rotationInput > 128) {
             delta = -256 + rotationInput; // Counterclockwise rotation is sent starting at 255 so this converts it to a meaningful negative number
             this.isPressed
@@ -334,9 +333,7 @@ export class PowerMate extends EventEmitter {
                 )
               : this.emit(PowerMateEvents.CLOCKWISE, { delta });
           }
-          // Reset debouncer "isReady" flag for next input
-          this.rotationDebouncer.isReady = true;
-        }, this.rotationDebouncer.WAIT_MS);
+        });
       }
     };
 

--- a/bonk/src/devices/powermate/device.ts
+++ b/bonk/src/devices/powermate/device.ts
@@ -27,8 +27,6 @@ const sensitivity = {
   MULTI_PRESS_MS: 500,
   /** Debounce "wait" milliseconds for rotation inputs to alter the "sensitivity" of the knob rotation inputs. A higher value here means it takes more turning to trigger the inputs */
   ROTATION_WAIT_MS: 100,
-  /** Debounce "wait" milliseconds for press rotation inputs. Press rotation should be even less sensitive than regular rotation inputs. */
-  PRESS_ROTATION_WAIT_MS: 100,
 };
 
 /** For storing and passing around LED-related values in a structured way */
@@ -54,7 +52,6 @@ export class PowerMate extends EventEmitter {
   private longPress: PressTimer;
   private multiPress: PressTimer;
   private rotationDebouncer: Debouncer;
-  private pressRotationDebouncer: Debouncer;
   private ledState: LedState;
 
   constructor() {
@@ -108,11 +105,6 @@ export class PowerMate extends EventEmitter {
       timer: undefined,
       isReady: true,
       WAIT_MS: sensitivity.ROTATION_WAIT_MS,
-    };
-    this.pressRotationDebouncer = {
-      timer: undefined,
-      isReady: true,
-      WAIT_MS: sensitivity.PRESS_ROTATION_WAIT_MS,
     };
     this.ledState = {
       isOn: true,
@@ -321,16 +313,12 @@ export class PowerMate extends EventEmitter {
           if (rotationInput > 128) {
             delta = -256 + rotationInput; // Counterclockwise rotation is sent starting at 255 so this converts it to a meaningful negative number
             this.isPressed
-              ? withDebouncer(this.pressRotationDebouncer, () =>
-                  this.emit(PowerMateEvents.PRESS_COUNTERCLOCKWISE, { delta })
-                )
+              ? this.emit(PowerMateEvents.PRESS_COUNTERCLOCKWISE, { delta })
               : this.emit(PowerMateEvents.COUNTERCLOCKWISE, { delta });
           } else {
             delta = rotationInput; // Clockwise rotation is sent starting at 1, so it will already be a meaningful positive number
             this.isPressed
-              ? withDebouncer(this.pressRotationDebouncer, () =>
-                  this.emit(PowerMateEvents.PRESS_CLOCKWISE, { delta })
-                )
+              ? this.emit(PowerMateEvents.PRESS_CLOCKWISE, { delta })
               : this.emit(PowerMateEvents.CLOCKWISE, { delta });
           }
         });

--- a/bonk/src/devices/powermate/device.ts
+++ b/bonk/src/devices/powermate/device.ts
@@ -322,19 +322,15 @@ export class PowerMate extends EventEmitter {
           if (rotationInput > 128) {
             delta = -256 + rotationInput; // Counterclockwise rotation is sent starting at 255 so this converts it to a meaningful negative number
             this.isPressed
-              ? this.emitWithDebouncer(
-                  PowerMateEvents.PRESS_COUNTERCLOCKWISE,
-                  { delta },
-                  this.pressRotationDebouncer
+              ? this.withDebouncer(this.pressRotationDebouncer, () =>
+                  this.emit(PowerMateEvents.PRESS_COUNTERCLOCKWISE, { delta })
                 )
               : this.emit(PowerMateEvents.COUNTERCLOCKWISE, { delta });
           } else {
             delta = rotationInput; // Clockwise rotation is sent starting at 1, so it will already be a meaningful positive number
             this.isPressed
-              ? this.emitWithDebouncer(
-                  PowerMateEvents.PRESS_CLOCKWISE,
-                  { delta },
-                  this.pressRotationDebouncer
+              ? this.withDebouncer(this.pressRotationDebouncer, () =>
+                  this.emit(PowerMateEvents.PRESS_CLOCKWISE, { delta })
                 )
               : this.emit(PowerMateEvents.CLOCKWISE, { delta });
           }
@@ -357,15 +353,14 @@ export class PowerMate extends EventEmitter {
   }
 
   /**
-   * emitWithDebouncer
+   * withDebouncer
    *
-   * @param event The event to emit when the debounce is ready
-   * @param data The data to send along with the event emitter
    * @param debouncer The `Debouncer` object with `timer`, `isReady`, and `WAIT_MS`
+   * @param fn The function to call when the debouncer is ready
    */
-  private emitWithDebouncer(event: string, data: {}, debouncer: Debouncer) {
+  private withDebouncer(debouncer: Debouncer, fn: () => void) {
     if (debouncer.isReady) {
-      this.emit(event, { data });
+      fn();
     }
     // Set up debouncer for future events
     debouncer.isReady = false;

--- a/bonk/src/devices/utils.ts
+++ b/bonk/src/devices/utils.ts
@@ -10,6 +10,23 @@ export type Debouncer = {
   WAIT_MS: number;
 };
 
+/**
+ * withDebouncer
+ *
+ * @param debouncer The `Debouncer` object with `timer`, `isReady`, and `WAIT_MS`
+ * @param fn The function to call when the debouncer is ready
+ */
+export const withDebouncer = (debouncer: Debouncer, fn: () => void) => {
+  if (debouncer.isReady) {
+    fn();
+  }
+  // Set up debouncer for future events
+  debouncer.isReady = false;
+  debouncer.timer = setTimeout(() => {
+    debouncer.isReady = true;
+  }, debouncer.WAIT_MS);
+};
+
 /** Timers for long/multi press events */
 export type PressTimer = {
   /** The count for number of presses within a given timeout (for double- and triple-press) */


### PR DESCRIPTION
I realized this was limiting my ability to make the events type-safe so I decided to refactor the `emitWithDebouncer` function to be independent of events/emitters/etc

Now they are just ~`useDebouncer`~ `withDebouncer` and take a Debouncer and a function to call once the debouncer is ready