### PR TITLE
bonk: Use TypedEmitter to make sure events are typed

### DIFF
--- a/bonk/package-lock.json
+++ b/bonk/package-lock.json
@@ -9420,6 +9420,12 @@
       "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
       "dev": true
     },
+    "typed-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.3.1.tgz",
+      "integrity": "sha512-2h7utWyXgd2R2u2IuL8B4yu1gqMxbgUj2VS/MGVbFhEVQNJKXoQQoS5CBMh+eW31zFeSmDfEQ3qQf4xy5SlPVQ==",
+      "dev": true
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",

--- a/bonk/package.json
+++ b/bonk/package.json
@@ -59,6 +59,7 @@
     "rimraf": "^3.0.2",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.3",
+    "typed-emitter": "^1.3.1",
     "typedoc": "^0.20.28",
     "typedoc-plugin-markdown": "^3.5.0",
     "typescript": "^4.1.3"

--- a/bonk/src/devices/nuimo/events.ts
+++ b/bonk/src/devices/nuimo/events.ts
@@ -1,19 +1,60 @@
+import { TouchGestureArea } from 'rocket-nuimo';
+
 /** Events for Nuimo discovery, connect, select/tap and rotation */
-export const NuimoEvents: { [eventName: string]: string } = {
-  DISCOVERY_STARTED: 'startDiscovery',
-  DISCOVERY_FINISHED: 'stopDiscovery',
-  DEVICE_CONNECTED: 'deviceConnected',
-  DEVICE_DISCONNECTED: 'deviceDisconnected',
-  SINGLE_PRESS: 'singlePress',
-  LONG_PRESS: 'longPress',
-  CLOCKWISE: 'clockwise',
-  COUNTERCLOCKWISE: 'counterclockwise',
-  PRESS_CLOCKWISE: 'pressClockwise',
-  PRESS_COUNTERCLOCKWISE: 'pressCounterclockwise',
-  SWIPE_LEFT: 'swipeLeft',
-  SWIPE_RIGHT: 'swipeRight',
-  SWIPE_UP: 'swipeUp',
-  SWIPE_DOWN: 'swipeDown',
-  TOUCH: 'touch',
-  LONG_TOUCH: 'longTouch',
+export const NuimoEvents = [
+  'discoveryStarted',
+  'discoveryFinished',
+  'deviceConnected',
+  'deviceDisconnected',
+  'singlePress',
+  'longPress',
+  'clockwise',
+  'counterclockwise',
+  'pressClockwise',
+  'pressCounterclockwise',
+  'swipeLeft',
+  'swipeRight',
+  'swipeUp',
+  'swipeDown',
+  'touch',
+  'longTouch',
+];
+
+/** Data to send with events for rotation (clockwise, counterclockwise, pressClockwise, or pressCounterclockwise) */
+export type RotationData = { delta: number };
+
+/** Data to send with events for device connection/disconnection */
+export type ConnectionData = {
+  id: string | undefined;
+  batteryLevel?: number | undefined;
 };
+
+/** Data to send with stopDiscovery event */
+export type DiscoveryFinished = {
+  success: boolean;
+};
+
+/** Data to send with touch and longTouch events */
+export type TouchData = {
+  area: TouchGestureArea;
+};
+
+/** Each possible event name, and the data that should be emitted with the event */
+export interface NuimoEvents {
+  discoveryStarted: () => void;
+  discoveryFinished: (data: DiscoveryFinished) => void;
+  deviceConnected: (data: ConnectionData) => void;
+  deviceDisconnected: (data: ConnectionData) => void;
+  singlePress: () => void;
+  longPress: () => void;
+  clockwise: (data: RotationData) => void;
+  counterclockwise: (data: RotationData) => void;
+  pressClockwise: (data: RotationData) => void;
+  pressCounterclockwise: (data: RotationData) => void;
+  swipeLeft: () => void;
+  swipeRight: () => void;
+  swipeUp: () => void;
+  swipeDown: () => void;
+  touch: (data: TouchData) => void;
+  longTouch: (data: TouchData) => void;
+}

--- a/bonk/src/devices/powermate/events.ts
+++ b/bonk/src/devices/powermate/events.ts
@@ -1,11 +1,26 @@
 /** Events for PowerMate button and rotation */
-export const PowerMateEvents: { [eventName: string]: string } = {
-  SINGLE_PRESS: 'singlePress',
-  DOUBLE_PRESS: 'doublePress',
-  TRIPLE_PRESS: 'triplePress',
-  LONG_PRESS: 'longPress',
-  CLOCKWISE: 'clockwise',
-  COUNTERCLOCKWISE: 'counterclockwise',
-  PRESS_CLOCKWISE: 'pressClockwise',
-  PRESS_COUNTERCLOCKWISE: 'pressCounterclockwise',
-};
+export const PowerMateEvents = [
+  'singlePress',
+  'doublePress',
+  'triplePress',
+  'longPress',
+  'clockwise',
+  'counterclockwise',
+  'pressClockwise',
+  'pressCounterclockwise',
+];
+
+/** Data to send with events for rotation (clockwise, counterclockwise, pressClockwise, or pressCounterclockwise) */
+export type RotationData = { delta: number };
+
+/** Each possible event name, and the data that should be emitted with the event */
+export interface PowerMateEvents {
+  singlePress: () => void;
+  doublePress: () => void;
+  triplePress: () => void;
+  longPress: () => void;
+  clockwise: (data: RotationData) => void;
+  counterclockwise: (data: RotationData) => void;
+  pressClockwise: (data: RotationData) => void;
+  pressCounterclockwise: (data: RotationData) => void;
+}

--- a/bonk/src/devices/sonos/events.ts
+++ b/bonk/src/devices/sonos/events.ts
@@ -1,6 +1,12 @@
 /** Events for Sonos play state updates */
-export const SonosEvents: { [eventName: string]: string } = {
-  PLAYING: 'isPlaying',
-  PAUSED: 'isPaused',
-  GROUP_CHANGED: 'groupChanged',
-};
+export const SonosEvents = ['isPlaying', 'isPaused', 'groupChanged'];
+
+/** Data to send with events for changes to groups for Sonos speakers */
+export type GroupChangedData = { isGrouped: boolean };
+
+/** Each possible event name, and the data that should be emitted with the event */
+export interface SonosEvents {
+  isPlaying: () => void;
+  isPaused: () => void;
+  groupChanged: (data: GroupChangedData) => void;
+}

--- a/bonk/src/index.ts
+++ b/bonk/src/index.ts
@@ -23,31 +23,31 @@ sonos.on('isPlaying', () => powermate.setLed({ isOn: true })); // Turn on PowerM
 sonos.on('isPaused', () => powermate.setLed({ isOn: false })); // Turn off PowerMate LED when Sonos is paused
 
 /** Nuimo Inputs */
-nuimo.on('clockwise', () => callAndShowGlyph(sonos.volumeUp, 'VOLUME_UP'));
+nuimo.on('clockwise', () =>
+  sonos.volumeUp()?.then(() => nuimo.displayGlyph(NuimoGlyphs['VOLUME_UP']))
+);
 nuimo.on('counterclockwise', () =>
-  callAndShowGlyph(sonos.volumeDown, 'VOLUME_DOWN')
+  sonos.volumeDown()?.then(() => nuimo.displayGlyph(NuimoGlyphs['VOLUME_DOWN']))
 );
 nuimo.on('pressClockwise', () =>
-  callAndShowGlyph(sonos.groupVolumeUp, 'GROUP_VOLUME_UP')
+  sonos
+    .groupVolumeUp()
+    ?.then(() => nuimo.displayGlyph(NuimoGlyphs['GROUP_VOLUME_UP']))
 );
 nuimo.on('pressCounterclockwise', () =>
-  callAndShowGlyph(sonos.groupVolumeDown, 'GROUP_VOLUME_DOWN')
+  sonos
+    .groupVolumeDown()
+    ?.then(() => nuimo.displayGlyph(NuimoGlyphs['GROUP_VOLUME_DOWN']))
 );
 nuimo.on('singlePress', () =>
   sonos.isPlaying
-    ? callAndShowGlyph(sonos.pause, 'PAUSE')
-    : callAndShowGlyph(sonos.play, 'PLAY')
+    ? sonos.pause()?.then(() => nuimo.displayGlyph(NuimoGlyphs['PAUSE']))
+    : sonos.play()?.then(() => nuimo.displayGlyph(NuimoGlyphs['PLAY']))
 );
-nuimo.on('swipeRight', () => callAndShowGlyph(sonos.next, 'NEXT'));
-nuimo.on('swipeLeft', () => callAndShowGlyph(sonos.previous, 'PREVIOUS'));
+nuimo.on('swipeRight', () =>
+  sonos.next()?.then(() => nuimo.displayGlyph(NuimoGlyphs['NEXT']))
+);
+nuimo.on('swipeLeft', () =>
+  sonos.previous()?.then(() => nuimo.displayGlyph(NuimoGlyphs['PREVIOUS']))
+);
 nuimo.on('longTouch', () => nuimo.displayGlyph(NuimoGlyphs['WAKE_UP']));
-
-/** Helper for Nuimo to call a function then show a glyph from NuimoGlyphs */
-const callAndShowGlyph = (
-  fn: () => Promise<any> | undefined,
-  glyph: keyof NuimoGlyphs
-) => {
-  fn()
-    ?.then(() => nuimo.displayGlyph(NuimoGlyphs[glyph], { timeoutMs: 100 }))
-    .catch(() => nuimo.displayGlyph(NuimoGlyphs.ERROR));
-};

--- a/bonk/src/index.ts
+++ b/bonk/src/index.ts
@@ -1,120 +1,53 @@
-import { Nuimo, NuimoEvents, NuimoGlyphs } from './devices/nuimo';
-import { PowerMate, PowerMateEvents } from './devices/powermate';
-import { Sonos, SonosEvents } from './devices/sonos';
+import { Nuimo, NuimoGlyphs } from './devices/nuimo';
+import { PowerMate } from './devices/powermate';
+import { Sonos } from './devices/sonos';
 
-/** Make devices */
 const powermate = new PowerMate();
 const nuimo = new Nuimo();
 const sonos = new Sonos();
 
-/**
- * PowerMate Inputs
- *
- * Maps each PowerMate input event to methods on other devices
- */
-const PowerMateInputs: { [eventName: string]: () => void } = {
-  CLOCKWISE: () => sonos.volumeUp(),
-  PRESS_CLOCKWISE: () => sonos.groupVolumeUp(),
-  COUNTERCLOCKWISE: () => sonos.volumeDown(),
-  PRESS_COUNTERCLOCKWISE: () => sonos.groupVolumeDown(),
-  SINGLE_PRESS: () => sonos.togglePlay(),
-  DOUBLE_PRESS: () => sonos.next(),
-  TRIPLE_PRESS: () => sonos.previous(),
-  LONG_PRESS: () => nuimo.connect(), // Long Press reconnects Nuimo if it gets disconnected
+/** PowerMate Inputs */
+powermate.on('clockwise', () => sonos.volumeUp());
+powermate.on('pressClockwise', () => sonos.groupVolumeUp());
+powermate.on('counterclockwise', () => sonos.volumeDown());
+powermate.on('pressCounterclockwise', () => sonos.groupVolumeDown());
+powermate.on('singlePress', () => sonos.togglePlay());
+powermate.on('doublePress', () => sonos.next());
+powermate.on('triplePress', () => sonos.previous());
+powermate.on('longPress', () => nuimo.connect()); // Long Press reconnects Nuimo if it gets disconnected
+
+/** PowerMate LED */
+nuimo.on('discoveryStarted', () => powermate.setLed({ isPulsing: true })); // Start pulsing PowerMate LED when reconnecting Nuimo
+nuimo.on('discoveryFinished', () => powermate.setLed({ isPulsing: false })); // Stop pulsing PowerMate LED when Nuimo is reconnected
+sonos.on('isPlaying', () => powermate.setLed({ isOn: true })); // Turn on PowerMate LED when Sonos is playing
+sonos.on('isPaused', () => powermate.setLed({ isOn: false })); // Turn off PowerMate LED when Sonos is paused
+
+/** Nuimo Inputs */
+nuimo.on('clockwise', () => callAndShowGlyph(sonos.volumeUp, 'VOLUME_UP'));
+nuimo.on('counterclockwise', () =>
+  callAndShowGlyph(sonos.volumeDown, 'VOLUME_DOWN')
+);
+nuimo.on('pressClockwise', () =>
+  callAndShowGlyph(sonos.groupVolumeUp, 'GROUP_VOLUME_UP')
+);
+nuimo.on('pressCounterclockwise', () =>
+  callAndShowGlyph(sonos.groupVolumeDown, 'GROUP_VOLUME_DOWN')
+);
+nuimo.on('singlePress', () =>
+  sonos.isPlaying
+    ? callAndShowGlyph(sonos.pause, 'PAUSE')
+    : callAndShowGlyph(sonos.play, 'PLAY')
+);
+nuimo.on('swipeRight', () => callAndShowGlyph(sonos.next, 'NEXT'));
+nuimo.on('swipeLeft', () => callAndShowGlyph(sonos.previous, 'PREVIOUS'));
+nuimo.on('longTouch', () => nuimo.displayGlyph(NuimoGlyphs['WAKE_UP']));
+
+/** Helper for Nuimo to call a function then show a glyph from NuimoGlyphs */
+const callAndShowGlyph = (
+  fn: () => Promise<any> | undefined,
+  glyph: keyof NuimoGlyphs
+) => {
+  fn()
+    ?.then(() => nuimo.displayGlyph(NuimoGlyphs[glyph], { timeoutMs: 100 }))
+    .catch(() => nuimo.displayGlyph(NuimoGlyphs.ERROR));
 };
-
-for (const i in PowerMateInputs) {
-  powermate.on(PowerMateEvents[i], PowerMateInputs[i]);
-}
-
-/**
- * PowerMate LED Events
- *
- * List of events on other devices that affect the PowerMate LED
- *
- * - While the Nuimo is connecting, pulse the PowerMate LED
- * - When Sonos is playing/paused, turn on/off the PowerMate LED
- *
- * This is implemented kind of backwards from the other listeners, in that
- * the other device is the source of the event, instead of the PowerMate.
- * I did it this way just for the code organization/folding.
- */
-const PowerMateLedEvents = [
-  // Start pulsing PowerMate LED when reconnecting Nuimo
-  () =>
-    nuimo.on(NuimoEvents.DISCOVERY_STARTED, () =>
-      powermate.setLed({ isPulsing: true })
-    ),
-  // Stop pulsing PowerMate LED when Nuimo is reconnected
-  () =>
-    nuimo.on(NuimoEvents.DISCOVERY_FINISHED, () =>
-      powermate.setLed({ isPulsing: false })
-    ),
-  // Turn on PowerMate LED when Sonos is playing
-  () => sonos.on(SonosEvents.PLAYING, () => powermate.setLed({ isOn: true })),
-  // Turn off PowerMate LED when Sonos is paused
-  () => sonos.on(SonosEvents.PAUSED, () => powermate.setLed({ isOn: false })),
-];
-
-for (const e in PowerMateLedEvents) {
-  PowerMateLedEvents[e]();
-}
-
-/**
- * Nuimo Inputs
- *
- * - Maps each Nuimo event to methods on other devices
- * - Displays a glyph after the method is complete
- */
-const NuimoInputs: { [eventName: string]: () => void } = {
-  CLOCKWISE: () => {
-    sonos.volumeUp()?.then(() =>
-      nuimo.displayGlyph(NuimoGlyphs.VOLUME_UP, {
-        timeoutMs: 100,
-      })
-    );
-  },
-  PRESS_CLOCKWISE: () => {
-    sonos
-      .groupVolumeUp()
-      ?.then(() =>
-        nuimo.displayGlyph(NuimoGlyphs.GROUP_VOLUME_UP, {
-          timeoutMs: 100,
-        })
-      )
-      .catch(() => nuimo.displayGlyph(NuimoGlyphs.ERROR));
-  },
-  COUNTERCLOCKWISE: () => {
-    sonos.volumeDown()?.then(() =>
-      nuimo.displayGlyph(NuimoGlyphs.VOLUME_DOWN, {
-        timeoutMs: 100,
-      })
-    );
-  },
-  PRESS_COUNTERCLOCKWISE: () => {
-    sonos
-      .groupVolumeDown()
-      ?.then(() =>
-        nuimo.displayGlyph(NuimoGlyphs.GROUP_VOLUME_DOWN, {
-          timeoutMs: 100,
-        })
-      )
-      .catch(() => nuimo.displayGlyph(NuimoGlyphs.ERROR));
-  },
-  SINGLE_PRESS: () => {
-    if (sonos.isPlaying) {
-      sonos.pause()?.then(() => nuimo.displayGlyph(NuimoGlyphs.PAUSE));
-    } else {
-      sonos.play()?.then(() => nuimo.displayGlyph(NuimoGlyphs.PLAY));
-    }
-  },
-  SWIPE_RIGHT: () =>
-    sonos.next()?.then(() => nuimo.displayGlyph(NuimoGlyphs.NEXT)),
-  SWIPE_LEFT: () =>
-    sonos.previous()?.then(() => nuimo.displayGlyph(NuimoGlyphs.PREVIOUS)),
-  LONG_TOUCH: () => nuimo.displayGlyph(NuimoGlyphs.WAKE_UP),
-};
-
-for (const i in NuimoInputs) {
-  nuimo.on(NuimoEvents[i], NuimoInputs[i]);
-}


### PR DESCRIPTION
Previously, my type checking would not catch bad event names or data

TypedEmitter enforces that you define both the events and the data they return in an interface

![Typed events in Bonk](https://user-images.githubusercontent.com/3157928/110074541-624c7b80-7d4f-11eb-8a9d-06a50abcd6af.png)
_(now VS Code will show me suggestions for event names 😱 )_

So I did this, and reworked PowerMate to use that structure for its events

I also refactored the index quite a bit, because there were annoying things with the types when I tried to iterate through all keys in the events to set up an event listener for each ... this gets back to the fact that I can't iterate through keys in an interface in TypeScript

I looked into a package called ts-transformer-keys but it had some weird stuff that had to happen in the compilation steps with Rollup in TSDX, so I decided against it in favor of keeping the setup simpler and not getting off the rails (https://github.com/kimamula/ts-transformer-keys)